### PR TITLE
Add the ability to cancel due. New field 'cancel_due' is added 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.13.0] - 2022-12-01
+### Added
+- 'cancel_due' property in :obj:models.requests.TaskCommentRequest request
+
 ## [2.12.0] - 2022-06-22
 ### Added
 - 'due_filter' property in :obj:models.requests.TaskListRequest request

--- a/pyrus/client.py
+++ b/pyrus/client.py
@@ -46,7 +46,7 @@ class PyrusAPI(object):
     access_token = None
     _protocol = 'https'
     _api_name = 'Pyrus'
-    _user_agent = 'Pyrus API python client v 2.12.0'
+    _user_agent = 'Pyrus API python client v 2.13.0'
     proxy = None
     _download_file_base_url = 'https://files.pyrus.com/services/attachment?Id='
 

--- a/pyrus/models/requests.py
+++ b/pyrus/models/requests.py
@@ -363,12 +363,6 @@ class TaskCommentRequest(object):
             if not isinstance(cancel_due, bool):
                 raise TypeError('cancel_due must be a bool')
             self.cancel_due = cancel_due
-            if hasattr(self, 'due_date'):
-                delattr(self, 'due_date')
-            if hasattr(self, 'due'):
-                delattr(self, 'due')
-            if hasattr(self, 'duration'):
-                delattr(self, 'duration')
         if scheduled_date:
             if not isinstance(scheduled_date, datetime):
                 raise TypeError('scheduled_date must be a date')

--- a/pyrus/models/requests.py
+++ b/pyrus/models/requests.py
@@ -184,6 +184,7 @@ class TaskCommentRequest(object):
             due (:obj:`datetime`, optional): task due date with time (either due_date or due can be used)
             due_date (:obj:`datetime`, optional): task due date (either due_date or due can be used)
             duration (:obj:`int`, optional): duration of the event in minutes (it can only be used with due)
+            cancel_due (:obj:`bool`, optional): Flag indicating that due (due_date) should be cancelled. The due, due_date, duration will be set to null
             subject (:obj:`str`, optional): New task subject
         Args(Form task comment):
             approval_choice (:obj:`str`, optional): Approval choice (approved/rejected/acknowledged)
@@ -198,7 +199,7 @@ class TaskCommentRequest(object):
     def __init__(self, text=None, approval_choice=None, approval_steps=None, action=None,
                  attachments=None, field_updates=None, approvals_added=None,
                  participants_added=None, reassign_to=None, due=None, due_date=None,
-                 duration=None, scheduled_date=None, scheduled_datetime_utc=None,
+                 duration=None, cancel_due=None, scheduled_date=None, scheduled_datetime_utc=None,
                  cancel_schedule=None, added_list_ids=None, removed_list_ids=None,
                  approvals_removed=None, approvals_rerequested=None, subscribers_added=None, subscribers_removed=None,
                  subscribers_rerequested=None, subject=None,
@@ -358,6 +359,16 @@ class TaskCommentRequest(object):
             if not due:
                 raise ValueError("duration can only be used with due")
             self.duration = duration
+        if cancel_due:
+            if not isinstance(cancel_due, bool):
+                raise TypeError('cancel_due must be a bool')
+            self.cancel_due = cancel_due
+            if hasattr(self, 'due_date'):
+                delattr(self, 'due_date')
+            if hasattr(self, 'due'):
+                delattr(self, 'due')
+            if hasattr(self, 'duration'):
+                delattr(self, 'duration')
         if scheduled_date:
             if not isinstance(scheduled_date, datetime):
                 raise TypeError('scheduled_date must be a date')

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 setup(name="pyrus-api",
-      version="2.12.0",
+      version="2.13.0",
       python_requires='>=3.4',
       description="Python Pyrus API client",
       author="Pyrus",


### PR DESCRIPTION
Added a new json property 'cancel_due'.
Once this property is set to true in a request, propertues 'due', 'due_date' and 'duration' are set to null.